### PR TITLE
Modified OUP plugin to add NC license with a trailing slash

### DIFF
--- a/openarticlegauge/plugins/oup.py
+++ b/openarticlegauge/plugins/oup.py
@@ -28,7 +28,14 @@ class OUPPlugin(plugin.Plugin):
                     + "\n" + ' '*21 +  "properly cited.":
                 {'type': 'cc-nc', 'version':'3.0',
                     # also declare some properties which override info about this license in the licenses list (see licenses module)
-                    'url': 'http://creativecommons.org/licenses/by-nc/3.0'}
+                    'url': 'http://creativecommons.org/licenses/by-nc/3.0/'}
+            },
+            {"This is an Open Access article distributed under the terms of the Creative Commons Attribution Non-Commercial License (http://creativecommons.org/licenses/by-nc/3.0/),"
+                    + "\n" + ' '*21 +  "which permits unrestricted non-commercial use, distribution, and reproduction in any medium, provided the original work is"
+                    + "\n" + ' '*21 +  "properly cited.":
+                {'type': 'cc-nc', 'version':'3.0',
+                    # also declare some properties which override info about this license in the licenses list (see licenses module)
+                    'url': 'http://creativecommons.org/licenses/by-nc/3.0/'}
             }
         ]
 

--- a/openarticlegauge/tests/test_oup.py
+++ b/openarticlegauge/tests/test_oup.py
@@ -19,6 +19,7 @@ class TestWorkflow(TestCase):
     def test_01_oup_supports_success(self):
         oup = OUPPlugin()
         test_urls = ["http://www.oxfordjournals.org/983242", "http://chemistry.oxfordjournals.org/2987433",
+        			 "http://schizophreniabulletin.oxfordjournals.org/content/40/1/169",
                         "https://www.biology.oxfordjournals.org/jsafkjsaf"]
         for url in test_urls:
             assert oup.supports({"url" : [url]})
@@ -191,3 +192,51 @@ class TestWorkflow(TestCase):
         + "This is an Open Access article distributed under the terms of the Creative Commons Attribution Non-Commercial License (http://creativecommons.org/licenses/by-nc/3.0)," \
         + "\n" + ' '*21 + "which permits unrestricted non-commercial use, distribution, and reproduction in any medium, provided the original work is" \
         + "\n" + ' '*21 + 'properly cited.".'
+        
+    def test_06_oup_OA_NC_license2(self):
+        record = {}
+        record['bibjson'] = {}
+        record['provider'] = {}
+        record['provider']['url'] = ['http://schizophreniabulletin.oxfordjournals.org/content/40/1/169']
+        record = models.MessageObject(record=record)
+        
+        oup = OUPPlugin()
+        oup.license_detect(record)
+
+        record = record.record
+        
+        # check if all the important keys were created
+        assert record['bibjson'].has_key('license')
+        assert record['bibjson']['license']
+
+        # NB: some examples may fail the 'url' test since the Open Definition
+        # data we're using as the basis for our licenses dictionary does not
+        # have 'url' for all licenses. Fix by modifying licenses.py - add the data.
+        assert all (key in record['bibjson']['license'][-1] for key in keys_in_license)
+
+        assert all (key in record['bibjson']['license'][-1]['provenance'] for key in keys_in_provenance)
+
+        # some content checks now
+        assert record['bibjson']['license'][-1]['type'] == 'cc-nc'
+        assert record['bibjson']['license'][-1]['version'] == '3.0'
+        assert 'id' not in record['bibjson']['license'][-1] # should not have "id" - due to bibserver
+        assert not record['bibjson']['license'][-1]['jurisdiction']
+        assert not record['bibjson']['license'][-1]['open_access']
+        assert record['bibjson']['license'][-1]['BY']
+        assert record['bibjson']['license'][-1]['NC']
+        assert not record['bibjson']['license'][-1]['SA']
+        assert not record['bibjson']['license'][-1]['ND']
+        # In this case we also expect the OUP plugin to overwrite the ['license']['url']
+        # property with a more specific one from the license statement.
+        assert record['bibjson']['license'][-1]['url'] == 'http://creativecommons.org/licenses/by-nc/3.0'
+
+        assert record['bibjson']['license'][-1]['provenance']['agent'] == config.agent
+        assert record['bibjson']['license'][-1]['provenance']['source'] == record['provider']['url'][0]
+        assert record['bibjson']['license'][-1]['provenance']['date']
+        assert record['bibjson']['license'][-1]['provenance']['category'] == 'page_scrape'
+
+        assert record['bibjson']['license'][-1]['provenance']['description'] == 'License decided by scraping the resource at ' + record['provider']['url'][0] + ' and looking for the following license statement: "' \
+        + "This is an Open Access article distributed under the terms of the Creative Commons Attribution Non-Commercial License (http://creativecommons.org/licenses/by-nc/3.0/)," \
+        + "\n" + ' '*21 + "which permits unrestricted non-commercial use, distribution, and reproduction in any medium, provided the original work is" \
+        + "\n" + ' '*21 + 'properly cited.".'
+


### PR DESCRIPTION
In some cases the URL in the license text contains the trailing slash for the CC NC licenses and in some cases it doesn't. This was failing so have added the license statement with the trailing slash. There may also be some cases for the CC BY licenses but haven't found them yet.

See: https://github.com/CottageLabs/OpenArticleGauge/issues/73
